### PR TITLE
XTOTEM-57 : Totem application use "document" parameter instead of "re…

### DIFF
--- a/src/main/resources/TotemCode/EditContent.xml
+++ b/src/main/resources/TotemCode/EditContent.xml
@@ -42,8 +42,8 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>{{include document="DisplayerCode.DisplayerMacros" /}}
-{{include document="TotemCode.TotemMacros" /}}
+  <content>{{include reference='DisplayerCode.DisplayerMacros' /}}
+{{include reference='TotemCode.TotemMacros' /}}
 {{velocity }}
 #set($action = $request.action)
 #set($totemDocRef = $request.totemDocRef)

--- a/src/main/resources/TotemCode/SimpleTotemItemClass.xml
+++ b/src/main/resources/TotemCode/SimpleTotemItemClass.xml
@@ -52,7 +52,7 @@
     <nameField/>
     <validationScript/>
     <date>
-      <customDisplay>{{include document="AppWithinMinutes.Date"/}}</customDisplay>
+      <customDisplay>{{include reference='AppWithinMinutes.Date' /}}</customDisplay>
       <dateFormat>dd.MM.yyyy</dateFormat>
       <disabled>0</disabled>
       <emptyIsToday>0</emptyIsToday>

--- a/src/main/resources/TotemCode/SimpleTotemItemTemplate.xml
+++ b/src/main/resources/TotemCode/SimpleTotemItemTemplate.xml
@@ -53,7 +53,7 @@
       <nameField/>
       <validationScript/>
       <date>
-        <customDisplay>{{include document="AppWithinMinutes.Date"/}}</customDisplay>
+        <customDisplay>{{include reference='AppWithinMinutes.Date' /}}</customDisplay>
         <dateFormat>dd.MM.yyyy</dateFormat>
         <disabled>0</disabled>
         <emptyIsToday>0</emptyIsToday>

--- a/src/main/resources/TotemCode/SimpleTotemItemTemplateProvider.xml
+++ b/src/main/resources/TotemCode/SimpleTotemItemTemplateProvider.xml
@@ -168,6 +168,6 @@
       <type>page</type>
     </property>
   </object>
-  <content>{{include document="XWiki.TemplateProviderSheet"/}}
+  <content>{{include reference='XWiki.TemplateProviderSheet' /}}
 </content>
 </xwikidoc>

--- a/src/main/resources/TotemCode/TotemSheet.xml
+++ b/src/main/resources/TotemCode/TotemSheet.xml
@@ -1316,9 +1316,9 @@ XWiki.widgets.TotemModalPopup = Class.create(XWiki.widgets.ModalPopup, {
       <use>currentPage</use>
     </property>
   </object>
-  <content>{{include document="DisplayerCode.DisplayerMacros" /}}
+  <content>{{include reference='DisplayerCode.DisplayerMacros' /}}
 
-{{include document="TotemCode.TotemMacros" /}}
+{{include reference='TotemCode.TotemMacros' /}}
 
 {{velocity output="false"}}
 $xwiki.ssx.use('DisplayerCode.DisplayerMacros')

--- a/src/main/resources/TotemCode/TotemsList.xml
+++ b/src/main/resources/TotemCode/TotemsList.xml
@@ -49,7 +49,7 @@
 {{info}} $services.localization.render("totem.home.createtoteminfo") {{/info}}
 )))
 ## Totem creation form
-{{include document='TotemCode.CreateTotem'/}}
+{{include reference='TotemCode.CreateTotem' /}}
 ## Totem listing
 #set($columns = ["doc.name","doc.fullName", "doc.date", "doc.author", "_actions"])
 #set($columnsProperties = {


### PR DESCRIPTION
…ference" in all include macros
- replaced "document" parameter with "reference" in all "include" macro calls
- replaced all double quotes with single quotes in the same macro calls
